### PR TITLE
Automatic shell detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -634,6 +634,12 @@
         "@types/webidl-conversions": "*"
       }
     },
+    "@types/which": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
+      "integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
+      "dev": true
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.10.1.tgz",
@@ -4146,8 +4152,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -7419,7 +7424,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "xterm-addon-fit": "0.4.0",
     "xterm-addon-ligatures": "^0.3.0",
     "xterm-addon-web-links": "0.4.0",
-    "xterm-addon-webgl": "0.9.0"
+    "xterm-addon-webgl": "0.9.0",
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "@types/atom": "1.40.4",
@@ -64,6 +65,7 @@
     "@types/node": "^14.11.2",
     "@types/uuid": "^8.3.0",
     "@types/whatwg-url": "^8.0.0",
+    "@types/which": "^1.3.2",
     "atom-jasmine3-test-runner": "^5.1.2",
     "build-commit": "0.1.1",
     "cross-env": "7.0.2",

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -1,9 +1,9 @@
 /** @babel */
 
-import { getDefaultShell } from "../dist/config"
+import { getFallbackShell } from "../dist/config"
 
 describe("config", () => {
-  describe("getDefaultShell()", () => {
+  describe("getFallbackShell()", () => {
     const savedPlatform = process.platform
     let savedEnv
 
@@ -25,7 +25,7 @@ describe("config", () => {
       if (process.env.COMSPEC) {
         delete process.env.COMSPEC
       }
-      expect(getDefaultShell()).toBe("cmd.exe")
+      expect(getFallbackShell()).toBe("cmd.exe")
     })
 
     it("on win32 with COMSPEC set", () => {
@@ -34,7 +34,7 @@ describe("config", () => {
       })
       const expected = "somecommand.exe"
       process.env.COMSPEC = expected
-      expect(getDefaultShell()).toBe(expected)
+      expect(getFallbackShell()).toBe(expected)
     })
 
     it("on linux without SHELL set", () => {
@@ -44,7 +44,7 @@ describe("config", () => {
       if (process.env.SHELL) {
         delete process.env.SHELL
       }
-      expect(getDefaultShell()).toBe("/bin/sh")
+      expect(getFallbackShell()).toBe("/bin/sh")
     })
 
     it("on linux with SHELL set", () => {
@@ -53,7 +53,7 @@ describe("config", () => {
       })
       const expected = "somecommand"
       process.env.SHELL = expected
-      expect(getDefaultShell()).toBe(expected)
+      expect(getFallbackShell()).toBe(expected)
     })
   })
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import which from "which"
+import { existsSync } from "fs"
 
 type configObjects = Record<string, configObject>
 
@@ -58,8 +59,19 @@ export function getFallbackShell() {
 // set start command asyncronously
 export async function setShellStartCommand() {
   if (localStorage.getItem("terminal.autoShell") === "true") {
+    // first check the cache
+    const defaultSellCache = localStorage.getItem("terminal.defaultSellCache")
+    if (defaultSellCache && existsSync(defaultSellCache)) {
+      atom.config.set("terminal.shell", defaultSellCache)
+      return
+    }
+
+    // find prefered shell
     const shellStartCommand = await getDefaultShell()
     atom.config.set("terminal.shell", shellStartCommand)
+
+    // cache the result for faster restoration in later loads
+    localStorage.setItem("terminal.defaultSellCache", shellStartCommand)
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,7 @@ function configOrder(obj: configObjects): configObjects {
 }
 
 // finds the default shell start commmand
-async function getDefaultShell(): Promise<string> {
+export async function getDefaultShell(): Promise<string> {
   let shellStartCommand
   if (process.platform === "win32") {
     // Windows
@@ -52,7 +52,7 @@ async function getDefaultShell(): Promise<string> {
 }
 
 // The shell command used in case getDefaultShell does not find a prefered shell
-function getFallbackShell() {
+export function getFallbackShell() {
   return process.platform === "win32" ? process.env.COMSPEC || "cmd.exe" : process.env.SHELL || "/bin/sh"
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import which from "which"
 type configObjects = Record<string, configObject>
 
 type configObject = {
@@ -24,7 +25,29 @@ function configOrder(obj: configObjects): configObjects {
   return obj
 }
 
-export function getDefaultShell(): string {
+// finds the default shell start commmand
+async function getDefaultShell(): Promise<string> {
+  let shellStartCommand
+  if (process.platform === "win32") {
+    // Windows
+    try {
+      shellStartCommand = await which("pwsh.exe")
+      return shellStartCommand
+    } catch (e1) {
+      try {
+        shellStartCommand = await which("powershell.exe")
+        return shellStartCommand
+      } catch (e2) {
+        shellStartCommand = process.env.COMSPEC || "cmd.exe"
+        return shellStartCommand
+      }
+    }
+  } else {
+    // Unix
+    shellStartCommand = process.env.SHELL || "/bin/sh"
+    return shellStartCommand
+  }
+}
   return process.platform === "win32" ? process.env.COMSPEC || "cmd.exe" : process.env.SHELL || "/bin/sh"
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,4 @@
 import which from "which"
-import { CompositeDisposable } from "atom"
 
 type configObjects = Record<string, configObject>
 
@@ -57,17 +56,11 @@ export function getFallbackShell() {
 }
 
 // set start command asyncronously
-export async function setShellStartCommand(disposables: CompositeDisposable) {
+export async function setShellStartCommand() {
   if (localStorage.getItem("terminal.autoShell") === "true") {
     const shellStartCommand = await getDefaultShell()
     atom.config.set("terminal.shell", shellStartCommand)
   }
-  return disposables.add(
-    // an observre that checks if command has been edited manually, if so it will turn autoShell off
-    atom.config.observe("terminal.shell", () => {
-      localStorage.setItem("terminal.autoShell", "false")
-    })
-  )
 }
 
 export const config = configOrder({

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,9 @@ async function getDefaultShell(): Promise<string> {
     return shellStartCommand
   }
 }
+
+// The shell command used in case getDefaultShell does not find a prefered shell
+function getFallbackShell() {
   return process.platform === "win32" ? process.env.COMSPEC || "cmd.exe" : process.env.SHELL || "/bin/sh"
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,6 @@
 import which from "which"
+import { CompositeDisposable } from "atom"
+
 type configObjects = Record<string, configObject>
 
 type configObject = {
@@ -52,6 +54,20 @@ async function getDefaultShell(): Promise<string> {
 // The shell command used in case getDefaultShell does not find a prefered shell
 function getFallbackShell() {
   return process.platform === "win32" ? process.env.COMSPEC || "cmd.exe" : process.env.SHELL || "/bin/sh"
+}
+
+// set start command asyncronously
+export async function setShellStartCommand(disposables: CompositeDisposable) {
+  if (atom.config.get("terminal.autoShell")) {
+    const shellStartCommand = await getDefaultShell()
+    atom.config.set("terminal.shell", shellStartCommand)
+  }
+  return disposables.add(
+    // an observre that checks if command has been edited manually, if so it will turn autoShell off
+    atom.config.observe("terminal.shell", () => {
+      atom.config.set("terminal.autoShell", false)
+    })
+  )
 }
 
 export const config = configOrder({

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,7 +58,17 @@ export function getFallbackShell() {
 
 // set start command asyncronously
 export async function setShellStartCommand() {
-  if (localStorage.getItem("terminal.autoShell") === "true") {
+  // If set, automatically detect the prefered shell start command in the next Atom restart.
+  // (it will switched off if you edit `shell` option manually.
+  let shouldAutoShell = localStorage.getItem("terminal.autoShell")
+
+  // set for the first time
+  if (!shouldAutoShell) {
+    localStorage.setItem("terminal.autoShell", "true")
+    shouldAutoShell = "true"
+  }
+
+  if (shouldAutoShell === "true") {
     // first check the cache
     const defaultSellCache = localStorage.getItem("terminal.defaultSellCache")
     if (defaultSellCache && existsSync(defaultSellCache)) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,7 +82,7 @@ export const config = configOrder({
     title: "Shell",
     description: "Path to the shell command.",
     type: "string",
-    default: getDefaultShell(),
+    default: getFallbackShell(),
   },
   encoding: {
     title: "Character Encoding",

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,26 +58,19 @@ export function getFallbackShell() {
 
 // set start command asyncronously
 export async function setShellStartCommand(disposables: CompositeDisposable) {
-  if (atom.config.get("terminal.autoShell")) {
+  if (localStorage.getItem("terminal.autoShell") === "true") {
     const shellStartCommand = await getDefaultShell()
     atom.config.set("terminal.shell", shellStartCommand)
   }
   return disposables.add(
     // an observre that checks if command has been edited manually, if so it will turn autoShell off
     atom.config.observe("terminal.shell", () => {
-      atom.config.set("terminal.autoShell", false)
+      localStorage.setItem("terminal.autoShell", "false")
     })
   )
 }
 
 export const config = configOrder({
-  autoShell: {
-    title: "Automatic shell detection",
-    description:
-      "Automatically detect the prefered shell start command in the next Atom restart. (it will switched off if you edit `shell` option manually.",
-    type: "boolean",
-    default: true,
-  },
   shell: {
     title: "Shell",
     description: "Path to the shell command.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,13 @@ export async function setShellStartCommand(disposables: CompositeDisposable) {
 }
 
 export const config = configOrder({
+  autoShell: {
+    title: "Automatic shell detection",
+    description:
+      "Automatically detect the prefered shell start command in the next Atom restart. (it will switched off if you edit `shell` option manually.",
+    type: "boolean",
+    default: true,
+  },
   shell: {
     title: "Shell",
     description: "Path to the shell command.",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -20,11 +20,6 @@ class Terminal {
     // Set holding all terminals available at any moment.
     this.terminalsSet = new Set()
 
-    // set autoShell flag in local storage
-    // If set, automatically detect the prefered shell start command in the next Atom restart.
-    // (it will switched off if you edit `shell` option manually.
-    localStorage.setItem("terminal.autoShell", "true")
-
     // set start command asyncronously
     // TODO does any part of the code rely on this? If so we should await the promise before there
     setShellStartCommand().catch(() => {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -27,15 +27,19 @@ class Terminal {
 
     // set start command asyncronously
     // TODO does any part of the code rely on this? If so we should await the promise before there
-    setShellStartCommand(this.disposables).catch(() => {
+    setShellStartCommand().catch(() => {
       // run again with autoShell being false
       localStorage.setItem("terminal.autoShell", "false")
-      setShellStartCommand(this.disposables).catch((e) => {
+      setShellStartCommand().catch((e) => {
         throw e
       })
     })
 
     this.disposables.add(
+      // an observre that checks if command has been edited manually, if so it will turn autoShell off
+      atom.config.observe("terminal.shell", () => {
+        localStorage.setItem("terminal.autoShell", "false")
+      }),
       // Register view provider for terminal emulator item.
       atom.views.addViewProvider(TerminalModel, (terminalModel) => {
         const terminalElement = new TerminalElement()

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -20,11 +20,16 @@ class Terminal {
     // Set holding all terminals available at any moment.
     this.terminalsSet = new Set()
 
+    // set autoShell flag in local storage
+    // If set, automatically detect the prefered shell start command in the next Atom restart.
+    // (it will switched off if you edit `shell` option manually.
+    localStorage.setItem("terminal.autoShell", "true")
+
     // set start command asyncronously
     // TODO does any part of the code rely on this? If so we should await the promise before there
     setShellStartCommand(this.disposables).catch(() => {
       // run again with autoShell being false
-      atom.config.set("x-terminal.spawnPtySettings.autoShell", false)
+      localStorage.setItem("terminal.autoShell", "false")
       setShellStartCommand(this.disposables).catch((e) => {
         throw e
       })

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2,7 +2,7 @@ import { CompositeDisposable, Workspace, Dock, WorkspaceOpenOptions } from "atom
 
 import { TerminalElement } from "./element"
 import { TerminalModel } from "./model"
-import { setShellStartCommand } from "./config"
+import { setShellStartCommand, getFallbackShell } from "./config"
 
 import { v4 as uuidv4 } from "uuid"
 
@@ -23,11 +23,7 @@ class Terminal {
     // set start command asyncronously
     // TODO does any part of the code rely on this? If so we should await the promise before there
     setShellStartCommand().catch(() => {
-      // run again with autoShell being false
-      localStorage.setItem("terminal.autoShell", "false")
-      setShellStartCommand().catch((e) => {
-        throw e
-      })
+      atom.config.set("terminal.shell", getFallbackShell())
     })
 
     this.disposables.add(

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2,6 +2,7 @@ import { CompositeDisposable, Workspace, Dock, WorkspaceOpenOptions } from "atom
 
 import { TerminalElement } from "./element"
 import { TerminalModel } from "./model"
+import { setShellStartCommand } from "./config"
 
 import { v4 as uuidv4 } from "uuid"
 
@@ -18,6 +19,16 @@ class Terminal {
 
     // Set holding all terminals available at any moment.
     this.terminalsSet = new Set()
+
+    // set start command asyncronously
+    // TODO does any part of the code rely on this? If so we should await the promise before there
+    setShellStartCommand(this.disposables).catch(() => {
+      // run again with autoShell being false
+      atom.config.set("x-terminal.spawnPtySettings.autoShell", false)
+      setShellStartCommand(this.disposables).catch((e) => {
+        throw e
+      })
+    })
 
     this.disposables.add(
       // Register view provider for terminal emulator item.


### PR DESCRIPTION
Fixes #22 

On Windows, as the default value for the config, this uses pwsh (PowerShellCore) if available on a system.  If not it will use powershell, and in the end, it will use cmd.

