### PR TITLE
feat: add terminal:clear command

### DIFF
--- a/keymaps/terminal.json
+++ b/keymaps/terminal.json
@@ -46,14 +46,16 @@
     "ctrl-shift-c": "terminal:copy",
     "shift-insert": "terminal:paste",
     "ctrl-shift-v": "terminal:paste",
-    "ctrl-shift-u": "terminal:unfocus"
+    "ctrl-shift-u": "terminal:unfocus",
+    "ctrl-l": "terminal:clear"
   },
   ".platform-win32 atom-terminal": {
     "ctrl-insert": "terminal:copy",
     "ctrl-shift-c": "terminal:copy",
     "shift-insert": "terminal:paste",
     "ctrl-shift-v": "terminal:paste",
-    "ctrl-shift-u": "terminal:unfocus"
+    "ctrl-shift-u": "terminal:unfocus",
+    "ctrl-l": "terminal:clear"
   },
   ".platform-darwin atom-terminal": {
     "ctrl-shift-c": "terminal:copy",
@@ -62,6 +64,7 @@
     "shift-insert": "terminal:paste",
     "cmd-c": "terminal:copy",
     "cmd-v": "terminal:paste",
-    "ctrl-shift-u": "terminal:unfocus"
+    "ctrl-shift-u": "terminal:unfocus",
+    "ctrl-l": "terminal:clear"
   }
 }

--- a/menus/terminal.json
+++ b/menus/terminal.json
@@ -14,6 +14,10 @@
         "command": "terminal:restart"
       },
       {
+        "label": "Clear",
+        "command": "terminal:clear"
+      },
+      {
         "type": "separator"
       },
       {

--- a/spec/element-spec.js
+++ b/spec/element-spec.js
@@ -768,4 +768,10 @@ describe("TerminalElement", () => {
     }
     expect(element.getXtermOptions()).toEqual(expected)
   })
+
+	it('clear terminal', () => {
+		spyOn(element.terminal, 'clear')
+		element.clear()
+		expect(element.terminal.clear).toHaveBeenCalled()
+	})
 })

--- a/spec/terminal-spec.js
+++ b/spec/terminal-spec.js
@@ -70,4 +70,63 @@ describe("terminal", () => {
       expect(newTerminal.runCommand).toHaveBeenCalledWith("command 2")
     })
   })
+
+  describe("performOnTerminal", () => {
+    let activeTerminal
+    beforeEach(() => {
+      activeTerminal = {
+        element: {
+          initializedPromise: Promise.resolve(),
+        },
+        exit: jasmine.createSpy('activeTerminal.exit'),
+        restartPtyProcess: jasmine.createSpy('activeTerminal.restartPtyProcess'),
+        copyFromTerminal: jasmine.createSpy('activeTerminal.copy').and.returnValue('copied'),
+        pasteToTerminal: jasmine.createSpy('activeTerminal.paste'),
+        clear: jasmine.createSpy('activeTerminal.clear'),
+      }
+      spyOn(terminal, 'getActiveTerminal').and.returnValue(activeTerminal)
+    })
+
+    describe('close()', () => {
+      it('closes terminal', async () => {
+        await terminal.close()
+
+        expect(activeTerminal.exit).toHaveBeenCalled()
+      })
+    })
+
+    describe('restart()', () => {
+      it('restarts terminal', async () => {
+        await terminal.restart()
+
+        expect(activeTerminal.restartPtyProcess).toHaveBeenCalled()
+      })
+    })
+
+    describe('copy()', () => {
+      it('copys terminal', async () => {
+        spyOn(atom.clipboard, 'write')
+        await terminal.copy()
+
+        expect(atom.clipboard.write).toHaveBeenCalledWith('copied')
+      })
+    })
+
+    describe('paste()', () => {
+      it('pastes terminal', async () => {
+        spyOn(atom.clipboard, 'read').and.returnValue('copied')
+        await terminal.paste()
+
+        expect(activeTerminal.pasteToTerminal).toHaveBeenCalledWith('copied')
+      })
+    })
+
+    describe('clear()', () => {
+      it('clears terminal', async () => {
+        await terminal.clear()
+
+        expect(activeTerminal.clear).toHaveBeenCalled()
+      })
+    })
+  });
 })

--- a/src/element.ts
+++ b/src/element.ts
@@ -353,6 +353,12 @@ export class AtomTerminal extends HTMLElement {
       this.terminal.focus()
     }
   }
+
+	clear () {
+		if (this.terminal) {
+			return this.terminal.clear()
+		}
+	}
 }
 
 // @ts-ignore // TODO This should be fixed soon https://developer.mozilla.org/en-US/docs/Web/API/Document/registerElement

--- a/src/model.ts
+++ b/src/model.ts
@@ -216,6 +216,12 @@ export class TerminalModel {
     }
   }
 
+	clear () {
+		if (this.element) {
+			return this.element.clear()
+		}
+	}
+
   setActive() {
     TerminalModel.recalculateActive(this.terminalsSet, this)
   }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -115,6 +115,7 @@ class Terminal {
         "terminal:copy": () => this.copy(),
         "terminal:paste": () => this.paste(),
         "terminal:unfocus": () => this.unfocus(),
+				'terminal:clear': () => this.clear(),
       })
     )
   }
@@ -346,6 +347,13 @@ class Terminal {
 
   unfocus() {
     atom.views.getView(atom.workspace).focus()
+  }
+
+  clear() {
+    const terminal = this.getActiveTerminal()
+    if (terminal) {
+      terminal.clear()
+    }
   }
 }
 


### PR DESCRIPTION
Add `terminal:clear` command to clear the screen and map it to <kbd>Ctrl</kbd> + <kbd>L</kbd> by default.

copied from https://github.com/bus-stop/x-terminal/pull/216