### PR TITLE
feat: add tree view context menu

### DIFF
--- a/menus/terminal.json
+++ b/menus/terminal.json
@@ -32,41 +32,41 @@
         "command": "terminal:close-all"
       }
     ],
-    "atom-text-editor": [
+    "atom-text-editor, .tree-view, .tab-bar": [
       {
         "label": "Terminal",
         "submenu": [
           {
             "label": "Open New Terminal",
-            "command": "terminal:open"
+            "command": "terminal:open-context-menu"
           },
           {
             "label": "Open New Terminal (Split Up)",
-            "command": "terminal:open-up"
+            "command": "terminal:open-up-context-menu"
           },
           {
             "label": "Open New Terminal (Split Down)",
-            "command": "terminal:open-down"
+            "command": "terminal:open-down-context-menu"
           },
           {
             "label": "Open New Terminal (Split Left)",
-            "command": "terminal:open-left"
+            "command": "terminal:open-left-context-menu"
           },
           {
             "label": "Open New Terminal (Split Right)",
-            "command": "terminal:open-right"
+            "command": "terminal:open-right-context-menu"
           },
           {
             "label": "Open New Terminal (Bottom Dock)",
-            "command": "terminal:open-bottom-dock"
+            "command": "terminal:open-bottom-dock-context-menu"
           },
           {
             "label": "Open New Terminal (Left Dock)",
-            "command": "terminal:open-left-dock"
+            "command": "terminal:open-left-dock-context-menu"
           },
           {
             "label": "Open New Terminal (Right Dock)",
-            "command": "terminal:open-right-dock"
+            "command": "terminal:open-right-dock-context-menu"
           },
           {
             "label": "Close All Terminals",

--- a/spec/model-spec.js
+++ b/spec/model-spec.js
@@ -89,6 +89,7 @@ describe("TerminalModel", () => {
 
   it("constructor with previous active item which exists in project path", async () => {
     const previousActiveItem = jasmine.createSpyObj("somemodel", ["getPath"])
+    previousActiveItem.getPath.and.returnValue("/some/dir/file")
     spyOn(atom.workspace, "getActivePaneItem").and.returnValue(previousActiveItem)
     const expected = ["/some/dir", null]
     spyOn(atom.project, "relativizePath").and.returnValue(expected)

--- a/spec/terminal-spec.js
+++ b/spec/terminal-spec.js
@@ -70,4 +70,31 @@ describe("terminal", () => {
       expect(newTerminal.runCommand).toHaveBeenCalledWith("command 2")
     })
   })
+
+	describe('open()', () => {
+		let uri
+		beforeEach(() => {
+			uri = terminal.generateNewUri()
+			spyOn(atom.workspace, 'open')
+		})
+
+		it('simple', async () => {
+			await terminal.open(uri)
+
+			expect(atom.workspace.open).toHaveBeenCalledWith(uri, {})
+		})
+
+		it('target to cwd', async () => {
+			const testPath = '/test/path'
+			spyOn(terminal, 'getPath').and.returnValue(testPath)
+			await terminal.open(
+				uri,
+				{ target: true },
+			)
+
+			const url = new URL(atom.workspace.open.calls.mostRecent().args[0])
+
+			expect(url.searchParams.get('cwd')).toBe(testPath)
+		})
+	})
 })


### PR DESCRIPTION
Adds context menu items to tree-view and tab-bar. When executing from tree-view or tab bar opens terminal in folder of selected item.

copied from https://github.com/bus-stop/x-terminal/pull/213